### PR TITLE
Only send notifications for subscriptions that are verified

### DIFF
--- a/ckanext/subscribe/notification.py
+++ b/ckanext/subscribe/notification.py
@@ -143,10 +143,12 @@ def get_objects_subscribed_to(subscription_frequency):
     objects_subscribed_to = defaultdict(list)  # {object_id: [subscriptions]}
     # direct subscriptions - i.e. datasets, orgs & groups
     for subscription in model.Session.query(Subscription) \
+            .filter(Subscription.verified.is_(True)) \
             .filter(Subscription.frequency == subscription_frequency).all():
         objects_subscribed_to[subscription.object_id].append(subscription)
     # also include the datasets attached to the subscribed orgs
     for subscription, package_id in model.Session.query(Subscription, Package.id) \
+            .filter(Subscription.verified.is_(True)) \
             .filter(Subscription.frequency == subscription_frequency) \
             .join(Group, Group.id == Subscription.object_id) \
             .filter(Group.state == 'active') \
@@ -156,6 +158,7 @@ def get_objects_subscribed_to(subscription_frequency):
         objects_subscribed_to[package_id].append(subscription)
     # also include the datasets attached to the subscribed orgs
     for subscription, package_id in model.Session.query(Subscription, Package.id) \
+            .filter(Subscription.verified.is_(True)) \
             .filter(Subscription.frequency == subscription_frequency) \
             .join(Group, Group.id == Subscription.object_id) \
             .filter(Group.state == 'active') \
@@ -301,8 +304,7 @@ def get_notifications_by_email(activities, objects_subscribed_to,
             # ignore activity that occurs before this subscription was created
             if subscription.created > activity.timestamp:
                 continue
-            if not subscription.verified:
-                continue
+
             notifications[subscription.email][subscription].append(activity)
 
     # dictize

--- a/ckanext/subscribe/notification.py
+++ b/ckanext/subscribe/notification.py
@@ -301,7 +301,8 @@ def get_notifications_by_email(activities, objects_subscribed_to,
             # ignore activity that occurs before this subscription was created
             if subscription.created > activity.timestamp:
                 continue
-
+            if not subscription.verified:
+                continue
             notifications[subscription.email][subscription].append(activity)
 
     # dictize


### PR DESCRIPTION
Previously, we never checked whether a subscription was verified before sending notifications to that email address. We should only send notifications to verified subscriptions, or there's no point in the verification.